### PR TITLE
Add .gitignore to exclude compiled binary objects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.suo


### PR DESCRIPTION
Add .gitignore to exclude compiled binary objects.
