### PR TITLE
Comment out the DefaultWebProxy property,

### DIFF
--- a/root/programs/C#/Frameworks/Infrastructure/Public/Util/Latebind.cs
+++ b/root/programs/C#/Frameworks/Infrastructure/Public/Util/Latebind.cs
@@ -36,7 +36,8 @@
 //*  2010/11/19  西野  大介        オーバーロード メソッド対応
 //*  2011/02/08  西野  大介        リファクタリング（CheckTypeOfMethodByName）
 //*  2012/08/25  西野  大介        Assembly.LoadFile → .Load（ASP.NETシャドウコピー対応）
-//*  2015/12/22  Sai            Replaced substring method with EndsWith string method in first Invoke method.        
+//*  2015/12/22  Sai            Replaced substring method with EndsWith string method in first Invoke method.
+//*  2016/01/08  Sai            Added ToLower method in first Invoke method.
 //**********************************************************************************
 
 using System.Reflection;
@@ -85,7 +86,7 @@ namespace Touryo.Infrastructure.Public.Util
             {
                 // アセンブリ ロード
                 string ext = ".dll";
-                if (assemblyName.EndsWith(ext))
+                if (assemblyName.ToLower().EndsWith(ext))
                 {
                     //  アセンブリ・ファイルのパス指定の場合、Assembly.LoadFile
                     mod = Assembly.LoadFile(assemblyName);


### PR DESCRIPTION
because there is no use of this property in the component.

fixed #130
WebProxy.GetDefaultProxy() method is now obsolete.