### PR TITLE
Fixed : "IE 11 ignores dialogWidth-Height" #74 (2) … _NoPostback method does not work because the return value of dialog is not returned.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,7 @@ Visual Studio 2015 など、新しい開発環境を使用する場合は、[テ
 ライセンス(license)
 
 #### [/root/](https://github.com/OpenTouryoProject/OpenTouryo/tree/master/root)
-VS2010, .NET3.5 のプログラム(Program of VS2010, .NET3.5.)
-
-※ 本体はサポートのための最も古い環境で開発されます。  
-   (The body will be developed in the oldest supported environment for support.)
+プログラム
 
 ##テンプレート・ベース(Templates base)
 テンプレート・ベースに同梱されるサンプルはOpen棟梁の評価に利用できます。

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
-﻿#Open棟梁(OpenTouryo)
-
- ”Open棟梁”は、長年の.NETアプリケーション開発実績にて蓄積したノウハウに基づき開発した.NET用アプリケーション フレームワークです。
+# Open棟梁(OpenTouryo)
+”Open棟梁”は、長年の.NETアプリケーション開発実績にて蓄積したノウハウに基づき開発した.NET用アプリケーション フレームワークです。
 (”OpenTouryo” , is an application framework for .NET which was developed using the accumulated know-how with a long track record in .NET application development.)
 
-##概要(summary)
+## 開発／動作環境(develop/run-time environment)
+このリポジトリのプログラムは、サポートされる最も古い開発／実行環境を使用して開発しています。 (I am developing the program of this repository, using the oldest supported develop/run-time environment.)
+- 開発環境 (develop environment)
+    - Visual Studio 2010
+- 実行環境 (run-time environment)
+    - .NET Framework 3.5 SP1
+
+Visual Studio 2015 など、新しい開発環境を使用する場合は、[テンプレート・ベース](https://github.com/OpenTouryoProject/OpenTouryoTemplates)を参照してください。 (If you want to use the latest develop environment (e.g. Visual Studio 2015), please refer [Templates base](https://github.com/OpenTouryoProject/OpenTouryoTemplates).)
+
+## 概要(summary)
 以下のファイルを参照してください。
 (Please refer to the following files.)
 
@@ -36,10 +44,7 @@
 VS2010, .NET3.5 のプログラム(Program of VS2010, .NET3.5.)
 
 ※ 本体はサポートのための最も古い環境で開発されます。  
-   (The body will be developed in the most old environment for support.)
-
-#### [/root_easysetup/](https://github.com/OpenTouryoProject/OpenTouryo/tree/master/root_easysetup )
-簡易セットアップ版プログラム(Easy Setup program version) 
+   (The body will be developed in the oldest supported environment for support.)
 
 ##テンプレート・ベース(Templates base)
 テンプレート・ベースに同梱されるサンプルはOpen棟梁の評価に利用できます。

--- a/root/programs/C#/Samples/WebApp_sample/ProjectX_sample/Framework/Js/common.js
+++ b/root/programs/C#/Samples/WebApp_sample/ProjectX_sample/Framework/Js/common.js
@@ -176,7 +176,7 @@ function Fx_OnSubmit() {
             // IE10.0で問題の報告を受けていません。 
         }
         else if (navigator.appVersion.indexOf("Trident/7") != -1) {
-            // IE11.0で問題が合った場合、報告をお願いします。
+            // IE11.0で問題があった場合、報告をお願いします。
         } 
 
         if (document.readyState == "complete") {

--- a/root/programs/VB/Samples/WebApp_sample/ProjectX_sample/Framework/Js/common.js
+++ b/root/programs/VB/Samples/WebApp_sample/ProjectX_sample/Framework/Js/common.js
@@ -176,7 +176,7 @@ function Fx_OnSubmit() {
             // IE10.0で問題の報告を受けていません。 
         }
         else if (navigator.appVersion.indexOf("Trident/7") != -1) {
-            // IE11.0で問題が合った場合、報告をお願いします。
+            // IE11.0で問題があった場合、報告をお願いします。
         } 
 
         if (document.readyState == "complete") {


### PR DESCRIPTION
fixed #74
- [Fix of window.returnValue issue that is occurred by IFRAME of IE11 correspondance. #105](https://github.com/SymphonyTeleca/OpenTouryo/pull/105)
- [Merged the issue of IE 11 ignores dialogWidth-Height from C# version #107](https://github.com/SymphonyTeleca/OpenTouryo/pull/107)
