### PR TITLE
Fixed : "Multiple contents applied to ContentPlaceHolder_A in testDLScreen." #238

### DIFF
--- a/root/programs/C#/Samples/WebApp_sample/ProjectX_sample/Aspx/testFxLayerP/testDLScreen.aspx
+++ b/root/programs/C#/Samples/WebApp_sample/ProjectX_sample/Aspx/testFxLayerP/testDLScreen.aspx
@@ -1,6 +1,6 @@
 ﻿<%@ Page Language="C#" MasterPageFile="~/Aspx/Common/testBlankScreen.master" AutoEventWireup="true" Inherits="ProjectX_sample.Aspx.TestFxLayerP.testDLScreen" Codebehind="testDLScreen.aspx.cs" %>
 
-<asp:Content ID="cphHeaderScripts" ContentPlaceHolderID="ContentPlaceHolder_A" Runat="Server">
+<asp:Content ID="cphHeaderScripts" ContentPlaceHolderID="cphHeaderScripts" Runat="Server">
     <!-- Head 部の ContentPlaceHolder -->
 </asp:Content>
 

--- a/root/programs/VB/Samples/WebApp_sample/ProjectX_sample/Aspx/testFxLayerP/testDLScreen.aspx
+++ b/root/programs/VB/Samples/WebApp_sample/ProjectX_sample/Aspx/testFxLayerP/testDLScreen.aspx
@@ -1,6 +1,6 @@
 ﻿<%@ Page Language="VB" MasterPageFile="~/Aspx/Common/testBlankScreen.master" AutoEventWireup="true" Inherits="ProjectX_sample.Aspx.TestFxLayerP.testDLScreen" Codebehind="testDLScreen.aspx.vb" %>
 
-<asp:Content ID="cphHeaderScripts" ContentPlaceHolderID="ContentPlaceHolder_A" Runat="Server">
+<asp:Content ID="cphHeaderScripts" ContentPlaceHolderID="cphHeaderScripts" Runat="Server">
     <!-- Head 部の ContentPlaceHolder -->
 </asp:Content>
 


### PR DESCRIPTION
@yusukemaegawa

fixed #238
Please check and merge.

This processing of opening this screen in the dialog is implemented by "window.showModalDialog"
instead of Pseudo dialog, so it will not work unless to use Internet Explorer.